### PR TITLE
Update glueviz package to 1.2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ source:
 
 build:
   number: 0
+  # Skipping unnecessary linux platforms that don't need viz.
+  skip: True  # [py<36 or ppc64le or s390x]
 
 requirements:
   is_meta_pkg: True
@@ -37,7 +39,7 @@ app:
   type: desk
 
 about:
-  home: http://glueviz.org
+  home: https://glueviz.org
   license: BSD 3-Clause
   license_file: LICENSE
   summary: Multi-dimensional linked data exploration

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
   run:
     - glue-core =={{version}}
-    - glue-vispy-viewers >=1.0
+    - glue-vispy-viewers >=1.0.3
 
 test:
   commands:
@@ -38,10 +38,16 @@ app:
 about:
   home: https://glueviz.org
   license: BSD-3-Clause
-  license_file_url: https://github.com/glue-viz/glueviz/blob/master/LICENSE
+  license_family: BSD
+  license_url: https://github.com/glue-viz/glueviz/blob/master/LICENSE
   dev_url: https://github.com/glue-viz/glueviz
   doc_url: http://docs.glueviz.org/
   summary: Multi-dimensional linked data exploration
+  description: |
+    This package does not contain any code, but instead
+    is a meta-package that depends on the core glue code as well as stable
+    plugins that we want to provide to users by default.  This installs
+    glue-core and glue-vispy-viewers.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,6 @@ package:
   name: glueviz
   version: {{version}}
 
-source:
-  path: @THISDIR@
-
 build:
   number: 0
   # Skipping unnecessary linux platforms that don't need viz.
@@ -40,8 +37,10 @@ app:
 
 about:
   home: https://glueviz.org
-  license: BSD 3-Clause
-  license_file: LICENSE
+  license: BSD-3-Clause
+  license_file_url: https://github.com/glue-viz/glueviz/blob/master/LICENSE
+  dev_url: https://github.com/glue-viz/glueviz
+  doc_url: http://docs.glueviz.org/
   summary: Multi-dimensional linked data exploration
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,9 @@ package:
 build:
   number: 0
   # Skipping unnecessary linux platforms that don't need viz.
-  skip: True  # [py<36 or ppc64le or s390x]
+  skip: True  # [py<37 or ppc64le or s390x]
 
 requirements:
-  is_meta_pkg: True
   host:
     - python
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,35 +5,25 @@
 # below since the only purpose of that command is to trigger the installation of the
 # dependencies.
 
-{% set version = "1.0.0" %}
+{% set version = "1.2.4" %}
 
 package:
   name: glueviz
   version: {{version}}
 
 source:
-  fn: glueviz-{{version}}.tar.gz
-  url: https://pypi.io/packages/source/g/glueviz/glueviz-{{version}}.tar.gz
-  sha256: 89db2b2331eb74f221251b129f6ce6b507f14101caea993ee0926ceeeaaf68ab
+  path: @THISDIR@
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  build:
-    - python
-    - pip
-    - setuptools >=30.3
-    - setuptools_scm
+  is_meta_pkg: True
   host:
     - python
-    - pip
-    - setuptools >=30.3
-    - setuptools_scm
   run:
-    - glue-core >=0.15.3
-    - glue-vispy-viewers >=0.12.2
+    - glue-core =={{version}}
+    - glue-vispy-viewers >=1.0
 
 test:
   commands:


### PR DESCRIPTION
Turning glueviz into a metapackage like pypi on pypi.org.